### PR TITLE
Fix package input editing on comparison URLs

### DIFF
--- a/app/[package]/components/footer.tsx
+++ b/app/[package]/components/footer.tsx
@@ -1,26 +1,34 @@
 "use client";
 
-import { PackageSearchIcon } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { Command } from "@/components/ui/command";
+import { useRouter, useSearchParams } from "next/navigation";
+import { PackageSearch } from "@/components/package-search";
 
 interface PackageFooterProps {
   packages: string[];
 }
 
-export const PackageFooter = ({ packages }: PackageFooterProps) => (
-  <footer className="flex items-center justify-center p-4">
-    <div className="absolute bottom-4 left-1/2 w-full max-w-xs -translate-x-1/2 md:max-w-md">
-      <Command className="w-full rounded-lg border">
-        <div className="flex items-center gap-2 px-3 py-2">
-          <PackageSearchIcon className="size-4 shrink-0 opacity-50" />
-          {packages.map((pkg) => (
-            <Badge key={pkg} variant="secondary">
-              {pkg}
-            </Badge>
-          ))}
-        </div>
-      </Command>
-    </div>
-  </footer>
-);
+export const PackageFooter = ({ packages }: PackageFooterProps) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handlePackagesChange = (nextPackages: string[]) => {
+    const pathname =
+      nextPackages.length > 0
+        ? `/${nextPackages.map(encodeURIComponent).join(",")}`
+        : "/";
+    const query = searchParams.toString();
+
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+  };
+
+  return (
+    <footer className="flex items-center justify-center p-4">
+      <PackageSearch
+        onPackagesChange={handlePackagesChange}
+        packages={packages}
+      />
+    </footer>
+  );
+};

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,7 +1,17 @@
+"use client";
+
+import { usePackages } from "@/providers/filters";
 import { PackageSearch } from "./package-search";
 
-export const Footer = () => (
-  <footer className="flex items-center justify-center p-4">
-    <PackageSearch />
-  </footer>
-);
+export const Footer = () => {
+  const [packages, setPackages] = usePackages();
+
+  return (
+    <footer className="flex items-center justify-center p-4">
+      <PackageSearch
+        onPackagesChange={(nextPackages) => setPackages(nextPackages)}
+        packages={packages}
+      />
+    </footer>
+  );
+};

--- a/components/package-search.tsx
+++ b/components/package-search.tsx
@@ -85,36 +85,34 @@ export const PackageSearch = ({
   return (
     <div className="absolute bottom-4 left-1/2 w-full max-w-xs -translate-x-1/2 md:max-w-md">
       <Command className="w-full rounded-lg border">
-        {shouldShowResults ? (
-          <CommandList>
-            {error ? (
-              <CommandEmpty>Failed to load packages. Try again.</CommandEmpty>
-            ) : null}
-            {showEmptyState ? (
-              <CommandEmpty className="flex items-center gap-2 p-4 text-muted-foreground text-sm">
-                <PackageSearchIcon className="size-3" /> No packages found.
-              </CommandEmpty>
-            ) : null}
-            {showResults ? (
-              <CommandGroup>
-                {data.objects.map((item) => (
-                  <CommandItem
-                    key={item.package.name}
-                    onSelect={() => handleSelect(item.package.name)}
-                    value={item.package.name}
-                  >
-                    <span className="shrink-0 truncate font-medium">
-                      {item.package.name}
-                    </span>
-                    <span className="truncate text-muted-foreground text-xs">
-                      {item.package.description}
-                    </span>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            ) : null}
-          </CommandList>
-        ) : null}
+        <CommandList>
+          {shouldShowResults && error ? (
+            <CommandEmpty>Failed to load packages. Try again.</CommandEmpty>
+          ) : null}
+          {shouldShowResults && showEmptyState ? (
+            <CommandEmpty className="flex items-center gap-2 p-4 text-muted-foreground text-sm">
+              <PackageSearchIcon className="size-3" /> No packages found.
+            </CommandEmpty>
+          ) : null}
+          {shouldShowResults && showResults ? (
+            <CommandGroup>
+              {data.objects.map((item) => (
+                <CommandItem
+                  key={item.package.name}
+                  onSelect={() => handleSelect(item.package.name)}
+                  value={item.package.name}
+                >
+                  <span className="shrink-0 truncate font-medium">
+                    {item.package.name}
+                  </span>
+                  <span className="truncate text-muted-foreground text-xs">
+                    {item.package.description}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          ) : null}
+        </CommandList>
         <div className="flex items-center gap-2 overflow-x-auto px-3">
           <PackageSearchIcon className="size-4 shrink-0 opacity-50" />
           {packages.map((pkg) => (

--- a/components/package-search.tsx
+++ b/components/package-search.tsx
@@ -9,7 +9,6 @@ import {
   searchPackages,
 } from "@/actions/package/search";
 import { cn } from "@/lib/utils";
-import { usePackages } from "@/providers/filters";
 import { Badge } from "./ui/badge";
 import {
   Command,
@@ -21,10 +20,17 @@ import {
 
 const DEBOUNCE_MS = 200;
 
-export const PackageSearch = () => {
+interface PackageSearchProps {
+  onPackagesChange: (packages: string[]) => void;
+  packages: string[];
+}
+
+export const PackageSearch = ({
+  onPackagesChange,
+  packages,
+}: PackageSearchProps) => {
   const [value, setValue] = useState("");
   const [debouncedValue, setDebouncedValue] = useState("");
-  const [packages, setPackages] = usePackages();
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -47,13 +53,13 @@ export const PackageSearch = () => {
 
   const handleSelect = (packageName: string) => {
     if (!packages.includes(packageName)) {
-      setPackages([...packages, packageName]);
+      onPackagesChange([...packages, packageName]);
     }
     setValue("");
   };
 
   const handleRemove = (packageName: string) => {
-    setPackages(packages.filter((pkg) => pkg !== packageName));
+    onPackagesChange(packages.filter((pkg) => pkg !== packageName));
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -68,7 +74,7 @@ export const PackageSearch = () => {
       event.preventDefault();
       const newPackages = [...packages];
       newPackages.pop();
-      setPackages(newPackages);
+      onPackagesChange(newPackages);
     }
   };
 
@@ -115,6 +121,7 @@ export const PackageSearch = () => {
             <Badge className="gap-1 pr-1 pl-2" key={pkg} variant="secondary">
               {pkg}
               <button
+                aria-label={`Remove ${pkg}`}
                 className="rounded-sm p-0.5 transition-colors hover:bg-secondary-foreground/20"
                 onClick={() => handleRemove(pkg)}
                 type="button"


### PR DESCRIPTION
## Summary

- reuse the editable package search on direct comparison URLs
- update the pathname when packages are added or removed
- preserve active chart query parameters during package changes
- add an accessible label to package removal buttons
- keep the combobox list mounted so `aria-controls` always references an existing element

## Verification

- `bun run build`
- `./node_modules/.bin/biome check -- "app/[package]/components/footer.tsx" components/footer.tsx components/package-search.tsx`
- browser-tested add, remove, backspace, scoped packages, query retention, and the homepage flow
- axe audit on the comparison footer: 0 violations

## Known / deferred

- `bun run check` still reports the pre-existing `useBlockStatements` violation in `components/chart.tsx:127`, which is outside this diff.